### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,15 @@ To enable commenting functionality, you need to update your models as follows:
 
 #### 1. Implement the Commenter contract
 
-In your **User** model, implement the `Commenter` contract:
+In your **User** model, implement the `Commenter` contract and use the `isCommenter` trait:
 
 ```php
 use Tilto\Commentable\Contracts\Commenter;
+use Tilto\Commentable\Traits\IsCommenter;
 
 class User extends Model implements Commenter
 {
-    // ...
+    use isCommenter;
 }
 ```
 


### PR DESCRIPTION
I think it's an oversight to add trait ```IsCommenter``` to User  model, because without it, when a comment is post or if you want to show a view page with ```CommentsEntry```, error Call to undefined method App\Models\User::getCommenterAvatar() displays.