### PR TITLE
Change import to plugin for Tailwind CSS typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Once you have a custom theme set up, add the plugin's views and CSS to your them
 > Add this to your theme CSS file:
 >
 > ```css
-> @import "@tailwindcss/typography";
+> @plugin "@tailwindcss/typography";
 > ```
 
 ### Behavior


### PR DESCRIPTION
As mentioned in [the official tailwind documentation](https://github.com/tailwindlabs/tailwindcss-typography?tab=readme-ov-file#installation)

The @import statement throws an error
```cli
vite v7.3.1 building client environment for production...
✓ 1 modules transformed.
✗ Build failed in 37ms
error during build:
[@tailwindcss/vite:generate:build] Can't resolve '@tailwindcss/typography' in '/var/www/html/resources/css/filament/admin'                                                    
file: /var/www/html/resources/css/filament/admin/theme.css
```