### PR TITLE
Fix policy registering

### DIFF
--- a/src/CommentableServiceProvider.php
+++ b/src/CommentableServiceProvider.php
@@ -90,7 +90,7 @@ class CommentableServiceProvider extends PackageServiceProvider
             }
         }
 
-        Gate::policy(Comment::class, config('commentable.comment.policy'));
+        Gate::policy(config('commentable.comment.model'), config('commentable.comment.policy'));
     }
 
     protected function getAssetPackageName(): ?string


### PR DESCRIPTION
In CommentableServiceProvider

```Gate::policy(Comment::class, config('commentable.comment.policy'));```

- ```Comment``` refer to :
use Tilto\Commentable\Livewire\Comment;

- And not using custom model set in config file.