### PR TITLE
Feat: pass commentable model to create policy for contextual authorization

### DIFF
--- a/resources/views/livewire/create-comment.blade.php
+++ b/resources/views/livewire/create-comment.blade.php
@@ -1,8 +1,8 @@
 <div>
-    @can('create', config('commentable.comment.model'))
+    @can('create', [config('commentable.comment.model'), $record])
         <div x-data="{ submitting: false }" @reset-submitting.window="submitting = false">
             {{ $this->form }}
-    
+
             <div @if($buttonPosition === 'right') class="fi-create-comment-actions" @endif>
                 <x-filament::button
                     wire:click="create"

--- a/src/Policies/CommentPolicy.php
+++ b/src/Policies/CommentPolicy.php
@@ -2,12 +2,13 @@
 
 namespace Tilto\Commentable\Policies;
 
+use Tilto\Commentable\Contracts\Commentable;
 use Tilto\Commentable\Contracts\Commenter;
 use Tilto\Commentable\Models\Comment;
 
 class CommentPolicy
 {
-    public function create(Commenter $user): bool
+    public function create(Commenter $user, ?Commentable $commentable = null): bool
     {
         return true;
     }

--- a/src/Traits/HasComments.php
+++ b/src/Traits/HasComments.php
@@ -22,7 +22,7 @@ trait HasComments
     {
         $commentModel = config('commentable.comment.model');
 
-        if ($author->cannot('create', $commentModel)) {
+        if ($author->cannot('create', [$commentModel, $commentable])) {
             throw new AuthorizationException('Cannot create comment');
         }
 


### PR DESCRIPTION
This PR adds support for contextual authorization in the `create` policy method by passing the `$commentable` model alongside the comment class. This is a small, non-breaking change that unlocks a common and legitimate use case that is currently impossible to implement cleanly. Indeed, sometimes, we need to check a custom condition in relation with commentable to open or close comments creation process.

### Explanation
The `create` policy method currently only receives the authenticated user, with no information about the model being commented on. This makes it impossible to write authorization rules that depend on the state of the commentable — for example:

- Prevent new comments on a past event or expired record
- Restrict commenting based on the commentable's status (`draft`, `closed`, `archived`)
- Allow commenting only to users who are related to the specific commentable (e.g. assigned members)



### Functioning
Laravel's Gate already supports passing extra arguments to policy methods via an array: `Gate::check('ability', [$modelClass, $extra])`. This PR simply leverages that built-in mechanism — no new concepts introduced, no new dependencies.

The `$commentable` parameter is typed against the existing `Commentable` contract and is **nullable with a default of `null`**, ensuring full **backwards compatibility**: existing custom policies that override `create(Commenter $user): bool` continue to work without any changes.

### Changes
- **`src/Policies/CommentPolicy.php`** — adds `?Commentable $commentable = null` to the `create` signature
- **`src/Traits/HasComments.php`** — passes `[$commentModel, $commentable]` to the Gate check
- **`resources/views/livewire/create-comment.blade.php`** — passes `$record` alongside the model class to the `@can` directive

### Usage after this change
Custom policies can now make decisions based on the commentable model:

```php
class CommentPolicy extends CommentablePolicy
{
    public function create(Commenter $user, ?Commentable $commentable = null): bool
    {
        // Example: close creation comments on past events
        if ($commentable?->event_date?->isPast()) {
            return false;
        }

        return true;
    }
}
```

Existing policies that do not declare the second parameter are unaffected.


- [x] Backwards compatible — existing `create` overrides require no changes
- [x] Follows the same pattern already used by `update`, `reply`, `react` and `delete` (which all receive a model as second argument)
- [x] No new dependencies
- [x] Consistent across both the server-side Gate check and the Blade `@can` directive