### PR TITLE
Show who reacted in a tooltip on each reaction pill

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ return [
     'reaction' => [
         'model' => Tilto\Commentable\Models\CommentReaction::class,
         'allowed' => ['👍', '❤️', '😂', '😮', '😢', '🤔'],
+        'show_reactors_tooltip' => true,
     ],
 ];
 ```
@@ -402,6 +403,7 @@ You can configure allowed reactions and the reaction model in `config/commentabl
 'reaction' => [
     'model' => Tilto\Commentable\Models\CommentReaction::class,
     'allowed' => ['👍', '❤️', '😂', '😮', '😢', '🤔'],
+    'show_reactors_tooltip' => true,
 ],
 ```
 
@@ -423,6 +425,19 @@ CommentsEntry::make('comments')
 If you do not set `allowedReactions`, the default set from your config will be used.
 
 Reactions are displayed below each comment, and users can add or remove their reaction. Each user can react once per reaction type per comment.
+
+##### Reactor tooltips
+
+Hovering a reaction shows a tooltip naming who reacted, e.g. "You reacted with 👍", "Moshe reacted with 👍" or "You and Moshe reacted with 👍". The phrasing is localized in all available languages, and the current user is always listed first as "you".
+
+The tooltip is enabled by default. To disable it and show only the emoji, set the following in your published `config/commentable.php` file:
+
+```php
+'reaction' => [
+    // ...
+    'show_reactors_tooltip' => false, // default: true
+],
+```
 
 #### Replies
 

--- a/config/commentable.php
+++ b/config/commentable.php
@@ -32,5 +32,6 @@ return [
     'reaction' => [
         'model' => CommentReaction::class,
         'allowed' => ['👍', '❤️', '😂', '😮', '😢', '🤔'],
+        'show_reactors_tooltip' => true,
     ],
 ];

--- a/resources/lang/en/translations.php
+++ b/resources/lang/en/translations.php
@@ -31,4 +31,12 @@ return [
     ],
     'reply' => 'Reply',
     'add_reaction' => 'Add reaction',
+    'reactions' => [
+        'you' => 'You',
+        'and' => ' and ',
+        'unknown_user' => 'Unknown user',
+        'reacted_by_you' => 'You reacted with :emoji',
+        'reacted_by_one' => ':user reacted with :emoji',
+        'reacted_by_many' => ':users reacted with :emoji',
+    ],
 ];

--- a/resources/lang/fr/translations.php
+++ b/resources/lang/fr/translations.php
@@ -31,4 +31,12 @@ return [
     ],
     'reply' => 'Répondre',
     'add_reaction' => 'Ajouter un commentaire',
+    'reactions' => [
+        'you' => 'Vous',
+        'and' => ' et ',
+        'unknown_user' => 'Utilisateur inconnu',
+        'reacted_by_you' => 'Vous avez réagi avec :emoji',
+        'reacted_by_one' => ':user a réagi avec :emoji',
+        'reacted_by_many' => ':users ont réagi avec :emoji',
+    ],
 ];

--- a/resources/lang/he/translations.php
+++ b/resources/lang/he/translations.php
@@ -31,4 +31,12 @@ return [
     ],
     'reply' => 'הגב',
     'add_reaction' => 'הוסף תגובה',
+    'reactions' => [
+        'you' => 'אתה',
+        'and' => ' ו',
+        'unknown_user' => 'משתמש לא ידוע',
+        'reacted_by_you' => 'אתה הגבת :emoji',
+        'reacted_by_one' => ':user הגיב :emoji',
+        'reacted_by_many' => ':users הגיבו :emoji',
+    ],
 ];

--- a/resources/lang/nl/translations.php
+++ b/resources/lang/nl/translations.php
@@ -31,4 +31,12 @@ return [
     ],
     'reply' => 'Beantwoorden',
     'add_reaction' => 'Voeg een reactie toe',
+    'reactions' => [
+        'you' => 'Jij',
+        'and' => ' en ',
+        'unknown_user' => 'Onbekende gebruiker',
+        'reacted_by_you' => 'Jij reageerde met :emoji',
+        'reacted_by_one' => ':user reageerde met :emoji',
+        'reacted_by_many' => ':users reageerden met :emoji',
+    ],
 ];

--- a/resources/views/livewire/comment-reactions.blade.php
+++ b/resources/views/livewire/comment-reactions.blade.php
@@ -6,7 +6,8 @@
                 <span wire:key="inline-reaction-button-{{ $reactionData['reaction'] }}-{{ $comment->id }}">
                     <button wire:click="toggleReaction('{{ $reactionData['reaction'] }}')" type="button"
                         class="fi-comment-reaction-button {{ $reactionData['reacted_by_current_user'] ? 'fi-comment-reaction-button--reacted' : 'fi-comment-reaction-button--not-reacted' }}"
-                        title="{{ $reactionData['reaction'] }}">
+                        x-tooltip="{ content: @js($reactionData['tooltip']), theme: $store.theme }"
+                        aria-label="{{ $reactionData['tooltip'] }}">
                         <span>{{ $reactionData['reaction'] }}</span>
                         <span
                             wire:key="inline-reaction-count-{{ $reactionData['reaction'] }}-{{ $comment->id }}">{{ $reactionData['count'] }}</span>

--- a/resources/views/livewire/comment-reactions.blade.php
+++ b/resources/views/livewire/comment-reactions.blade.php
@@ -6,8 +6,12 @@
                 <span wire:key="inline-reaction-button-{{ $reactionData['reaction'] }}-{{ $comment->id }}">
                     <button wire:click="toggleReaction('{{ $reactionData['reaction'] }}')" type="button"
                         class="fi-comment-reaction-button {{ $reactionData['reacted_by_current_user'] ? 'fi-comment-reaction-button--reacted' : 'fi-comment-reaction-button--not-reacted' }}"
-                        x-tooltip="{ content: @js($reactionData['tooltip']), theme: $store.theme }"
-                        aria-label="{{ $reactionData['tooltip'] }}">
+                        @if ($reactionData['tooltip'])
+                            x-tooltip="{ content: @js($reactionData['tooltip']), theme: $store.theme }"
+                            aria-label="{{ $reactionData['tooltip'] }}"
+                        @else
+                            title="{{ $reactionData['reaction'] }}"
+                        @endif>
                         <span>{{ $reactionData['reaction'] }}</span>
                         <span
                             wire:key="inline-reaction-count-{{ $reactionData['reaction'] }}-{{ $comment->id }}">{{ $reactionData['count'] }}</span>

--- a/src/Livewire/CommentReactions.php
+++ b/src/Livewire/CommentReactions.php
@@ -37,17 +37,53 @@ class CommentReactions extends Component
         return $this->comment->reactions
             ->groupBy('reaction')
             ->map(function ($group) use ($user) {
+                $reactedByCurrentUser = $user && $group->contains(
+                    fn ($reaction) => $reaction->reactor_id == $user->getKey() &&
+                    $reaction->reactor_type == $user->getMorphClass()
+                );
+
                 return [
                     'count' => $group->count(),
                     'reaction' => $group->first()->reaction,
-                    'reacted_by_current_user' => $user && $group->contains(
-                        fn ($reaction) => $reaction->reactor_id == $user->getKey() &&
-                        $reaction->reactor_type == $user->getMorphClass()
-                    ),
+                    'reacted_by_current_user' => $reactedByCurrentUser,
+                    'tooltip' => $this->reactorsTooltip($group, $reactedByCurrentUser, $user),
                 ];
             })
             ->sortByDesc('count')
             ->values()
             ->toArray();
+    }
+
+    protected function reactorsTooltip($group, bool $reactedByCurrentUser, $user): string
+    {
+        $emoji = $group->first()->reaction;
+
+        $names = collect();
+
+        if ($reactedByCurrentUser) {
+            $names->push(__('commentable::translations.reactions.you'));
+        }
+
+        foreach ($group as $reaction) {
+            $isCurrentUser = $user &&
+                $reaction->reactor_id == $user->getKey() &&
+                $reaction->reactor_type == $user->getMorphClass();
+
+            if ($isCurrentUser) {
+                continue;
+            }
+
+            $names->push($reaction->reactor?->getCommenterName()
+                ?? __('commentable::translations.reactions.unknown_user'));
+        }
+
+        return match (true) {
+            $names->count() === 1 && $reactedByCurrentUser => __('commentable::translations.reactions.reacted_by_you', ['emoji' => $emoji]),
+            $names->count() === 1 => __('commentable::translations.reactions.reacted_by_one', ['user' => $names->first(), 'emoji' => $emoji]),
+            default => __('commentable::translations.reactions.reacted_by_many', [
+                'users' => $names->join(', ', __('commentable::translations.reactions.and')),
+                'emoji' => $emoji,
+            ]),
+        };
     }
 }

--- a/src/Livewire/CommentReactions.php
+++ b/src/Livewire/CommentReactions.php
@@ -34,9 +34,11 @@ class CommentReactions extends Component
 
         $user = auth()->user();
 
+        $showReactorsTooltip = config('commentable.reaction.show_reactors_tooltip', true);
+
         return $this->comment->reactions
             ->groupBy('reaction')
-            ->map(function ($group) use ($user) {
+            ->map(function ($group) use ($user, $showReactorsTooltip) {
                 $reactedByCurrentUser = $user && $group->contains(
                     fn ($reaction) => $reaction->reactor_id == $user->getKey() &&
                     $reaction->reactor_type == $user->getMorphClass()
@@ -46,7 +48,9 @@ class CommentReactions extends Component
                     'count' => $group->count(),
                     'reaction' => $group->first()->reaction,
                     'reacted_by_current_user' => $reactedByCurrentUser,
-                    'tooltip' => $this->reactorsTooltip($group, $reactedByCurrentUser, $user),
+                    'tooltip' => $showReactorsTooltip
+                        ? $this->reactorsTooltip($group, $reactedByCurrentUser, $user)
+                        : null,
                 ];
             })
             ->sortByDesc('count')


### PR DESCRIPTION
## Summary

Each reaction pill now shows a tooltip naming who reacted, instead of just
repeating the emoji. Hovering a reaction now reads like "You reacted with 👍",
"Moshe reacted with 👍" or "You and Moshe reacted with 👍".

The phrasing is fully localized across all available languages (en, he, fr, nl),
including languages like Hebrew that conjugate the verb differently for the
"you" / single / multiple cases.

## Changes

- **`CommentReactions` Livewire component** – `reactionSummary()` now also builds
  a `tooltip` label for each emoji group. It collects the reactor names (listing
  the current user first as "you"), then selects one of three phrasings based on
  the reactor count. Falls back to an "unknown user" label when a reactor can no
  longer be resolved.
- **`comment-reactions.blade.php`** – the reaction pill now renders the reactor
  tooltip via Filament's `x-tooltip` (theme-aware) and an `aria-label` for screen
  readers, replacing the previous emoji-only `title`.
- **Translations** – added a `reactions` group with the new keys to all four
  language files (`en`, `he`, `fr`, `nl`).
