### PR TITLE
Add Ctrl+Enter / Cmd+Enter keyboard shortcut for submitting comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Inspired by and built upon code from the [Kirschbaum Commentions package](https:
         - [Polling](#polling)
         - [Reactions](#reactions)
         - [Replies](#replies)
+        - [Submit shortcut](#submit-shortcut)
 - [Styling](#styling)
     - [Behavior](#behavior)
 - [Testing](#testing)
@@ -115,6 +116,21 @@ return [
     */
     'reply' => [
         'allow_self_reply' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Editor
+    |--------------------------------------------------------------------------
+    |
+    | 'submit_shortcut' controls the keyboard shortcut for submitting a comment:
+    | - 'mod+enter': Ctrl + Enter (Windows/Linux) or Cmd + Enter (macOS)
+    | - 'enter': Enter submits, Shift + Enter inserts a new line
+    | - false: no keyboard shortcut
+    |
+    */
+    'editor' => [
+        'submit_shortcut' => 'mod+enter',
     ],
 
     /*
@@ -455,6 +471,24 @@ You can control whether the author of a comment may reply to their own comment u
     'allow_self_reply' => true, // default: false
 ],
 ```
+
+#### Submit shortcut
+
+By default, comments can be submitted with <kbd>Ctrl</kbd> + <kbd>Enter</kbd> (Windows/Linux) or <kbd>Cmd</kbd> + <kbd>Enter</kbd> (macOS). This applies to creating, editing, and replying to comments.
+
+You can customize this behavior in your published `config/commentable.php` file:
+
+```php
+'editor' => [
+    'submit_shortcut' => 'mod+enter', // default
+],
+```
+
+Supported values:
+
+- `'mod+enter'` — submit with <kbd>Ctrl</kbd> + <kbd>Enter</kbd> / <kbd>Cmd</kbd> + <kbd>Enter</kbd> (default)
+- `'enter'` — submit with <kbd>Enter</kbd>; use <kbd>Shift</kbd> + <kbd>Enter</kbd> to insert a new line
+- `false` — disable the keyboard shortcut entirely
 
 ## Styling
 

--- a/config/commentable.php
+++ b/config/commentable.php
@@ -26,6 +26,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Editor
+    |--------------------------------------------------------------------------
+    |
+    | 'submit_shortcut' controls the keyboard shortcut for submitting a comment:
+    | - 'mod+enter': Ctrl + Enter (Windows/Linux) or Cmd + Enter (macOS)
+    | - 'enter': Enter submits, Shift + Enter inserts a new line
+    | - false: no keyboard shortcut
+    |
+    */
+    'editor' => [
+        'submit_shortcut' => 'mod+enter',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Reaction
     |--------------------------------------------------------------------------
     */

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -70,7 +70,9 @@
                         :key="'reactions-' . $comment->id"
                     />
                 @else
-                    <form wire:submit="edit" class="fi-comment-edit-form">
+                    <form wire:submit="edit" class="fi-comment-edit-form"
+                        x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
+                        x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()">
                         {{ $this->form }}
 
                         <div
@@ -87,7 +89,9 @@
 
                 @if ($isNestable && $isReplying)
                     <div class="mt-4">
-                        <form wire:submit="reply">
+                        <form wire:submit="reply"
+                            x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
+                            x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()">
                             {{ $this->form }}
 
                             <div

--- a/resources/views/livewire/comment.blade.php
+++ b/resources/views/livewire/comment.blade.php
@@ -71,8 +71,7 @@
                     />
                 @else
                     <form wire:submit="edit" class="fi-comment-edit-form"
-                        x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
-                        x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()">
+                        @include('commentable::partials.submit-shortcut')>
                         {{ $this->form }}
 
                         <div
@@ -90,8 +89,7 @@
                 @if ($isNestable && $isReplying)
                     <div class="mt-4">
                         <form wire:submit="reply"
-                            x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
-                            x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()">
+                            @include('commentable::partials.submit-shortcut')>
                             {{ $this->form }}
 
                             <div

--- a/resources/views/livewire/create-comment.blade.php
+++ b/resources/views/livewire/create-comment.blade.php
@@ -1,8 +1,7 @@
 <div>
     @can('create', [config('commentable.comment.model'), $record])
         <form wire:submit="create"
-            x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
-            x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()">
+            @include('commentable::partials.submit-shortcut')>
             {{ $this->form }}
 
             <div @if($buttonPosition === 'right') class="fi-create-comment-actions" @endif>

--- a/resources/views/livewire/create-comment.blade.php
+++ b/resources/views/livewire/create-comment.blade.php
@@ -1,19 +1,19 @@
 <div>
     @can('create', [config('commentable.comment.model'), $record])
-        <div x-data="{ submitting: false }" @reset-submitting.window="submitting = false">
+        <form wire:submit="create"
+            x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
+            x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()">
             {{ $this->form }}
 
             <div @if($buttonPosition === 'right') class="fi-create-comment-actions" @endif>
                 <x-filament::button
-                    wire:click="create"
-                    x-on:click="submitting = true"
-                    ::disabled="submitting"
+                    type="submit"
                     class="fi-create-comment-submit"
                 >
                     {{ __('commentable::translations.buttons.post') }}
                 </x-filament::button>
             </div>
-        </div>
+        </form>
 
         <x-filament-actions::modals />
     @endcan

--- a/resources/views/partials/submit-shortcut.blade.php
+++ b/resources/views/partials/submit-shortcut.blade.php
@@ -1,0 +1,10 @@
+@php
+    $submitShortcut = config('commentable.editor.submit_shortcut', 'mod+enter');
+@endphp
+
+@if ($submitShortcut === 'mod+enter')
+    x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
+    x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()"
+@elseif ($submitShortcut === 'enter')
+    x-on:keydown.enter.capture="if (! $event.shiftKey) { $event.preventDefault(); $event.stopPropagation(); $el.requestSubmit(); }"
+@endif

--- a/resources/views/partials/submit-shortcut.blade.php
+++ b/resources/views/partials/submit-shortcut.blade.php
@@ -1,10 +1,10 @@
 @php
     $submitShortcut = config('commentable.editor.submit_shortcut', 'mod+enter');
-@endphp
 
-@if ($submitShortcut === 'mod+enter')
-    x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()"
-    x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()"
-@elseif ($submitShortcut === 'enter')
-    x-on:keydown.enter.capture="if (! $event.shiftKey) { $event.preventDefault(); $event.stopPropagation(); $el.requestSubmit(); }"
-@endif
+    $shortcutAttributes = match ($submitShortcut) {
+        'mod+enter' => 'x-on:keydown.ctrl.enter.capture.prevent.stop="$el.requestSubmit()" x-on:keydown.meta.enter.capture.prevent.stop="$el.requestSubmit()"',
+        'enter' => 'x-on:keydown.enter.capture="if (! $event.shiftKey) { $event.preventDefault(); $event.stopPropagation(); $el.requestSubmit(); }"',
+        default => '',
+    };
+@endphp
+{!! $shortcutAttributes !!}

--- a/src/Livewire/Actions/Create.php
+++ b/src/Livewire/Actions/Create.php
@@ -24,8 +24,6 @@ trait Create
             $this->dispatch('comment-created')->to(CommentList::class);
 
             $this->form->fill();
-
-            $this->dispatch('reset-submitting');
         } else {
             Notification::make()
                 ->title(__('commentable::translations.notifications.something_went_wrong'))


### PR DESCRIPTION
## Summary

Comments can now be submitted with a keyboard shortcut instead of only by clicking the button:

- **Ctrl + Enter** (Windows/Linux) or **Cmd + Enter** (macOS) submits the comment.
- Works in all three flows: creating a new comment, editing an existing one, and replying.

## Changes

- Wrapped the create-comment form in a real `<form wire:submit="create">` element and switched the button to `type="submit"`, so submissions go through a single, native path.
- Added `x-on:keydown.ctrl.enter` / `x-on:keydown.meta.enter` handlers (with `.capture.prevent.stop`) to the create, edit and reply forms, calling `$el.requestSubmit()`.
- Removed the manual `submitting` Alpine state and the `reset-submitting` event dispatch from the `Create` action — Livewire's native form submit handling covers the disabled/submitting state, so the extra bookkeeping is no longer needed.

## Files changed

- `resources/views/livewire/create-comment.blade.php`
- `resources/views/livewire/comment.blade.php`
- `src/Livewire/Actions/Create.php`

## Testing

- Create a comment and press Ctrl+Enter / Cmd+Enter — the comment is posted and the form resets.
- Same check while editing a comment and while replying to one.
- Clicking the Post button still works as before.
